### PR TITLE
Fix chat conversation duplication when calling LLM

### DIFF
--- a/chatbot/streamlit-chatbot/src/chatbot.py
+++ b/chatbot/streamlit-chatbot/src/chatbot.py
@@ -12,12 +12,18 @@ client = openai.OpenAI(
 )
 
 
-def llm_call(prompt, content):
+def llm_call(messages):
+    """Send the entire conversation to the LLM and return its reply.
+
+    Parameters
+    ----------
+    messages: list[dict]
+        A list of messages in the OpenAI chat format containing the
+        conversation history, including the system prompt.
+    """
+
     response = client.chat.completions.create(
         model="azure.gpt-4o-mini",
-        messages=[
-            {"role": "system", "content": "You are a helpful assistant"},
-            {"role": "user", "content": f"{prompt}:{content}"},
-        ],
+        messages=messages,
     )
     return response.choices[0].message.content

--- a/chatbot/streamlit-chatbot/src/main.py
+++ b/chatbot/streamlit-chatbot/src/main.py
@@ -49,12 +49,7 @@ if user_input:
             time.sleep(0.05)
             progress_bar.progress(percent, text="🤔 Thinking...")
         progress_bar.progress(90, text="✨ Finalizing response...")
-        prompt = "\n".join(
-            f"{msg['role'].capitalize()}: {msg['content']}"
-            for msg in st.session_state.messages
-            if msg["role"] != "system"
-        )
-        reply = llm_call(prompt, user_input)
+        reply = llm_call(st.session_state.messages)
         progress_bar.progress(100, text="✅ Done!")
         time.sleep(0.3)
         progress_bar.empty()


### PR DESCRIPTION
## Summary
- send the full conversation history to the LLM rather than concatenating text with the latest user input
- expose llm_call as a message-based helper

## Testing
- `pytest`
- `python -m py_compile chatbot/streamlit-chatbot/src/chatbot.py chatbot/streamlit-chatbot/src/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6895e9cb4a38832eab25e5d0902de276