### PR TITLE
fix: avoid duplicating user input in chat requests

### DIFF
--- a/chatbot/streamlit-chatbot/src/chatbot.py
+++ b/chatbot/streamlit-chatbot/src/chatbot.py
@@ -12,12 +12,12 @@ client = openai.OpenAI(
 )
 
 
-def llm_call(prompt, content):
+def llm_call(prompt: str) -> str:
     response = client.chat.completions.create(
         model="azure.gpt-4o-mini",
         messages=[
             {"role": "system", "content": "You are a helpful assistant"},
-            {"role": "user", "content": f"{prompt}:{content}"},
+            {"role": "user", "content": prompt},
         ],
     )
     return response.choices[0].message.content

--- a/chatbot/streamlit-chatbot/src/main.py
+++ b/chatbot/streamlit-chatbot/src/main.py
@@ -54,7 +54,7 @@ if user_input:
             for msg in st.session_state.messages
             if msg["role"] != "system"
         )
-        reply = llm_call(prompt, user_input)
+        reply = llm_call(prompt)
         progress_bar.progress(100, text="✅ Done!")
         time.sleep(0.3)
         progress_bar.empty()


### PR DESCRIPTION
## Summary
- prevent duplicate user input from being sent in chat prompt
- streamline llm_call to accept a single prompt argument

## Testing
- `python -m py_compile chatbot/streamlit-chatbot/src/chatbot.py chatbot/streamlit-chatbot/src/main.py && echo 'py_compile success'`
- `python - <<'PY'
import os, sys
os.environ['AZURE_API_KEY'] = 'test'
os.environ['AZURE_API_BASE'] = 'http://localhost'
sys.path.insert(0, 'chatbot/streamlit-chatbot/src')
import chatbot
from types import SimpleNamespace

def dummy_create(model, messages):
    print('model:', model)
    print('messages:', messages)
    return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content='stub reply'))])

chatbot.client.chat.completions.create = dummy_create

prompt = 'User: Hello\nAssistant: Hi there!\nUser: How are you?'
print('llm_call output:', chatbot.llm_call(prompt))
PY`


------
https://chatgpt.com/codex/tasks/task_e_6895ea9b6ff8832e9ae59728db4183ac